### PR TITLE
Af configure personal firestore

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,14 +5,21 @@ import {
 	Routes,
 	Route,
 } from 'react-router-dom';
-
 import { AddItem, Home, Layout, List } from './views';
-
-import { getItemData, streamListItems, comparePurchaseUrgency } from './api';
+import {
+	getItemData,
+	streamListItems,
+	comparePurchaseUrgency,
+	anonymouslyLogInUser,
+} from './api';
 import { useStateWithStorage } from './utils';
 
 export function App() {
+	// anytime the app loads, anonymously log in the user
+	anonymouslyLogInUser();
+
 	const [data, setData] = useState([]);
+
 	// Using a custom hook to create `listToken` and a function that can be used to update `listToken` later.
 	// listToken is null by default since new users will not have tokens
 	const [listToken, setListToken] = useStateWithStorage(

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -3,12 +3,12 @@ import { getFirestore } from 'firebase/firestore';
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
-	apiKey: 'AIzaSyCX-vM3JkbLC5dSBBeDQAgmmGEKU_269gY',
-	authDomain: 'tcl-51-smart-shopping-list.firebaseapp.com',
-	projectId: 'tcl-51-smart-shopping-list',
-	storageBucket: 'tcl-51-smart-shopping-list.appspot.com',
-	messagingSenderId: '970974663458',
-	appId: '1:970974663458:web:c60c278055491604890b7b',
+	apiKey: 'AIzaSyBi--Og0SaKCugMrZ6xtH23RRDmJI4P1KM',
+	authDomain: 'smart-shopping-list-c7108.firebaseapp.com',
+	projectId: 'smart-shopping-list-c7108',
+	storageBucket: 'smart-shopping-list-c7108.appspot.com',
+	messagingSenderId: '1040087405685',
+	appId: '1:1040087405685:web:7136928570d9e64fde943c',
 };
 
 // Initialize Firebase

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
@@ -11,6 +12,7 @@ const firebaseConfig = {
 	appId: '1:1040087405685:web:7136928570d9e64fde943c',
 };
 
-// Initialize Firebase
+// Initialize Firebase app, database, and authorization
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const auth = getAuth(app);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -10,7 +10,8 @@ import {
 	where,
 	getDocs,
 } from 'firebase/firestore';
-import { db } from './config';
+import { signInAnonymously } from 'firebase/auth';
+import { db, auth } from './config';
 import { getFutureDate, getDaysBetweenDates } from '../utils';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
@@ -23,6 +24,20 @@ export async function doesCollectionExist(listId) {
 	const listCollectionRef = collection(db, listId);
 	const testSnapshot = await getCountFromServer(listCollectionRef);
 	return testSnapshot.data().count !== 0;
+}
+
+/**
+ * Log user in anonymously using firebase authentication to allow CRUD operations in database
+ * Firebase docs do not specify behavior, but via testing:
+ * it looks like this creates a new anonymous user if user doesn't already have one, or if user already exists nothing changes
+ * Firebase appears to store/manage user data in user's browser for us
+ */
+export async function anonymouslyLogInUser() {
+	try {
+		await signInAnonymously(auth);
+	} catch (err) {
+		console.log(err);
+	}
 }
 
 /**


### PR DESCRIPTION
## Description
Created a Firebase application on my personal account and configured the application to use that database instead. 
In order to secure access to reading/writing in my Firestore database, added Firebase authorization to the project and configured it as well.

Firebase Auth provides the ability to anonymously log in users without needing them to make an account. Having this account, even though it's anonymous and the user doesn't know about it lets us limit read/write permission on the Firestore database to only authorized users to prevent abuse.

### Decisions/What I Learned
I originally was trying to check/manage whether the user was logged in or not and watch for changes to the user's state but was having issues. Decided instead to have the anonymous log in function run every time the App loads.

Firebase Auth documentation does not specify what happens when a user is already logged in and you try to log them in again. From testing however, the behavior appears to be:
- If a user does not exist / is not logged in, using the signInAnonymously function appears to create / log them in (account appears in Firebase Auth console)
- If a user is already logged in, calling this function again does not appear to have any effect

Firebase Auth has limits in place to prevent abuse already (only so many anonymous log-ins per hour from the same IP address) so it feels safe to use it this way. 

## Related Issue
closes #8 

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|     | :sparkles: New feature     |
| ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria
- pull down the branch and run `npm start` to view the site at localhost:3000
- check the Firebase Auth console to see the new anonymous user created
- interact with the application to trigger database changes and see that they go through (Make a list, add/delete items, etc)
- clear your local storage / cache / history etc and delete the anonymous user from the Firebase Auth console (or switch browsers) and comment out line 19 of App.jsx 
- without the anonymous login interacting with the application to view/change the list should print errors to the console, and not create/change the list in the Firestore dashboard
